### PR TITLE
Display version info, 30 second viewing time

### DIFF
--- a/installation/MacOs/update.command
+++ b/installation/MacOs/update.command
@@ -3,3 +3,7 @@
 echo "Updating InstaPy..."
 echo "===================="
 pip install -U instapy
+clear
+pip show instapy
+echo "This window will close in 30 seconds or you may choose to exit now once done viewing version info"
+sleep 30


### PR DESCRIPTION
Added functions to:
1. display version info of the most recent version of instapy that has just been installed.
2. Terminal will allow the user 30 seconds to view info on instapy package before closing itself