### PR TITLE
Added firefox 68 and clarifai installs

### DIFF
--- a/installation/Linux/install.sh
+++ b/installation/Linux/install.sh
@@ -13,6 +13,7 @@ else
   sudo apt-get -y upgrade
   sudo apt-get -y install unzip python3-pip python3-dev build-essential libssl-dev libffi-dev xvfb
   sudo pip3 install --upgrade pip
+  pip install clarifai --upgrade
   export LANGUAGE=en_US.UTF-8
   export LANG=en_US.UTF-8
   export LC_ALL=en_US.UTF-8
@@ -25,6 +26,18 @@ else
   sudo apt-get install -y -f
   sudo rm google-chrome-stable_current_amd64.deb
   pushd -0
+  
+  arch=$(uname -m)
+  if [ $arch == "x86_64" ]; then
+    wget https://ftp.mozilla.org/pub/firefox/releases/68.0/linux-x86_64/en-US/firefox-68.0.tar.bz2    
+  else
+    wget https://ftp.mozilla.org/pub/firefox/releases/68.0/linux-i686/en-US/firefox-68.0.tar.bz2    
+  fi
+  
+  tar -xjf firefox-68.0.tar.bz2
+  sudo mv firefox /opt/firefox68
+  sudo ln -s /opt/firefox68/firefox-bin /usr/bin/firefox
+  rm firefox-68.0.tar.bz2
 fi
 echo
 echo "Installing InstaPy..."


### PR DESCRIPTION
Added firefox 68 as it is required to not encounter issues with not being able to hide selenium plugin, leading to account banning if it goes unnoticed.
Added clarifai upgrade as a lot of people (including myself) encounter the `ERROR: clarifai 2.6.2 has requirement configparser<4,>=3.5, but you'll have configparser 5.0.0 which is incompatible.`