### PR TITLE
Replace InstapyFollowed usage with instapy_followed_enabled and py_followed_param

### DIFF
--- a/quickstart_templates/basic_follow-unfollow_activity.py
+++ b/quickstart_templates/basic_follow-unfollow_activity.py
@@ -53,7 +53,8 @@ with smart_run(session):
 
     """ First step of Unfollow action - Unfollow not follower users...
     """
-    session.unfollow_users(amount=500, InstapyFollowed=(True, "nonfollowers"),
+    session.unfollow_users(amount=500, instapy_followed_enabled=True,
+                           instapy_followed_param="nonfollowers",
                            style="FIFO",
                            unfollow_after=12 * 60 * 60, sleep_delay=601)
 
@@ -64,13 +65,14 @@ with smart_run(session):
 
     """ Second step of Unfollow action - Unfollow not follower users...
     """
-    session.unfollow_users(amount=500, InstapyFollowed=(True, "nonfollowers"),
+    session.unfollow_users(amount=500, instapy_followed_enabled=True,
+                           instapy_followed_param="nonfollowers",
                            style="FIFO",
                            unfollow_after=12 * 60 * 60, sleep_delay=601)
 
     """ Clean all followed user - Unfollow all users followed by InstaPy...
     """
-    session.unfollow_users(amount=500, InstapyFollowed=(True, "all"),
+    session.unfollow_users(amount=500, instapy_followed_enabled=True,
                            style="FIFO", unfollow_after=24 * 60 * 60,
                            sleep_delay=601)
 
@@ -90,4 +92,3 @@ with smart_run(session):
     session.set_do_comment(enabled = True, percentage = 95)
     session.set_comments(photo_comments, media = 'Photo')
     session.join_pods(topic='food', engagement_mode='no_comments')
-

--- a/quickstart_templates/friends_last_post_likes_and_interact_with_user_based_on_hashtahs.py
+++ b/quickstart_templates/friends_last_post_likes_and_interact_with_user_based_on_hashtahs.py
@@ -128,7 +128,7 @@ with smart_run(bot):
                              sleepyhead=True,
                              stochastic_flow=True,
                              notify_me=True,
-                             peak_likes_hourly=106, 
+                             peak_likes_hourly=106,
                              peak_likes_daily=585,
                              peak_follows_hourly=48,
                              peak_follows_daily=None,
@@ -205,12 +205,13 @@ with smart_run(bot):
         bot.set_blacklist(enabled=False,
                           campaign='blacklist')
         bot.unfollow_users(amount=random.randint(75, 100),
-                           InstapyFollowed=(True, "nonfollowers"),
+                           instapy_followed_enabled=True,
+                           instapy_followed_param="nonfollowers",
                            style="FIFO",
                            unfollow_after=72 * 60 * 60,
                            sleep_delay=600)
         bot.unfollow_users(amount=1000,
-                           InstapyFollowed=(True, "all"),
+                           instapy_followed_enabled=True,
                            style="FIFO",
                            unfollow_after=168 * 60 * 60,
                            sleep_delay=600)

--- a/quickstart_templates/good_usage_of_blacklist.py
+++ b/quickstart_templates/good_usage_of_blacklist.py
@@ -81,7 +81,7 @@ with smart_run(session):
         unfollowed for whatever reason.
     """
     session.set_blacklist(enabled=False, campaign='blacklist')
-    session.unfollow_users(amount=1000, InstapyFollowed=(True, "all"),
+    session.unfollow_users(amount=1000, instapy_followed_enabled=True,
                            style="FIFO", unfollow_after=None,
                            sleep_delay=600)
 

--- a/quickstart_templates/like_by_tag_interact_unfollow.py
+++ b/quickstart_templates/like_by_tag_interact_unfollow.py
@@ -60,7 +60,7 @@ with smart_run(session):
                          amount=random.randint(50, 100), interact=True)
 
     session.unfollow_users(amount=random.randint(75, 150),
-                           InstapyFollowed=(True, "all"), style="FIFO",
+                           instapy_followed_enabled=True, style="FIFO",
                            unfollow_after=90 * 60 * 60, sleep_delay=501)
 
     """ Joining Engagement Pods...

--- a/quickstart_templates/playing_around_with_quota_supervisor.py
+++ b/quickstart_templates/playing_around_with_quota_supervisor.py
@@ -81,7 +81,7 @@ with smart_run(session):
     # unfollow activity
     session.set_dont_unfollow_active_users(enabled=True, posts=3)
     session.unfollow_users(amount=random.randint(30, 100),
-                           InstapyFollowed=(True, "all"), style="FIFO",
+                           instapy_followed_enabled=True, style="FIFO",
                            unfollow_after=90 * 60 * 60, sleep_delay=501)
 
     """ Joining Engagement Pods...

--- a/quickstart_templates/stylish_unfollow_tips_and_like_by_tags.py
+++ b/quickstart_templates/stylish_unfollow_tips_and_like_by_tags.py
@@ -76,7 +76,8 @@ with smart_run(session):
         One week (168 * 60 * 60)
         Yes, I give a liberal one week time to follow [back] :)
     """
-    session.unfollow_users(amount=25, InstapyFollowed=(True, "nonfollowers"),
+    session.unfollow_users(amount=25, instapy_followed_enabled=True,
+                           instapy_followed_param="nonfollowers",
                            style="RANDOM",
                            unfollow_after=168 * 60 * 60,
                            sleep_delay=600)


### PR DESCRIPTION
On the last version of `Instapy`, using `InstapyFollowed` throws an error. Checking the usage, the implementation now uses `instapy_followed_enabled` and `instapy_followed_param` parameters. This PR addresses the issue.